### PR TITLE
Korjattu matkakortti maksukortiksi

### DIFF
--- a/web/materiaali.md
+++ b/web/materiaali.md
@@ -352,7 +352,7 @@ public class Kassapaate {
 }
 ```
 
-Kassapääte käyttää maksukortteja hetkellisesti lounaiden maksamisen ja rahan lataamisen yhteydessä. Kassapääte ei kuitenkaan muista pysyvästi yksittäisiä maksukortteja. Tämän takia kassapäätteellä on riippuvuus matkakortteihin, mutta ei kuitenkaan normaalia yhteyttä, sillä UML-kaavioon merkattu yhteys viittaa pysyvään, ajallisesti pidempikestoiseen suhteeseen.
+Kassapääte käyttää maksukortteja hetkellisesti lounaiden maksamisen ja rahan lataamisen yhteydessä. Kassapääte ei kuitenkaan muista pysyvästi yksittäisiä maksukortteja. Tämän takia kassapäätteellä on riippuvuus maksukortteihin, mutta ei kuitenkaan normaalia yhteyttä, sillä UML-kaavioon merkattu yhteys viittaa pysyvään, ajallisesti pidempikestoiseen suhteeseen.
 
 Tilannetta kuvaava luokkakaavio on seuraava:
 


### PR DESCRIPTION
Myös kuvassa lukee "matkakortti", vaikka pitäisi olla "maksukortti".