### PR TITLE
Update maven.md

### DIFF
--- a/web/maven.md
+++ b/web/maven.md
@@ -24,7 +24,7 @@ Lisää tiedostoon _pom.xml_ seuraavat
         <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.0</version>
+            <version>0.8.3</version>
             <executions>
                 <execution>
                     <id>default-prepare-agent</id>


### PR DESCRIPTION
Kehittäjän mukaan tällä kurssilla vaaditulle Java-versiolle 11 Jacocon tuki tuli vasta (Jacocon) versiossa 0.8.3. – en saanut ainakaan omaa testiluokkaani toimimaan ennen kuin tämä selitys löytyi ja vaihdoin pomiin Jacocon version.